### PR TITLE
buf: move FileVolatileSlice/FileVolatileBuf from fuse-backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "dbs-fuse"
+version = "0.1.0"
+license = "Apache-2.0"
+authors = ["Alibaba Dragonball Team"]
+description = "Utilities for tokio/tokio-uring based async IO"
+homepage = "https://github.com/openanolis/dragonball-sandbox"
+repository = "https://github.com/openanolis/dragonball-sandbox"
+keywords = ["async", "tokio", "tokio-uring"]
+readme = "README.md"
+edition = "2018"
+
+[dependencies]
+vm-memory = "0"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+tokio-uring = "0.3.0"
+
+[features]
+async-io = []
+
+[package.metadata.docs.rs]
+all-features = true
+targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "aarch64-apple-darwin"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# dbs-fuse
+
+The `dbs-fuse` is a utility crate to support [fuse-backend-rs](https://github.com/cloud-hypervisor/fuse-backend-rs).
+
+### Wrappers for Rust async io
+
+It's challenging to support Rust async io, and it's even more challenging to support Rust async io with Linux io-uring.
+
+The `dbs-fuse` crate adds a wrapper layer over [tokio](https://tokio.rs/) and [tokio-uring](https://github.com/tokio-rs/tokio-uring) to simplify the way to support Rust async io by providing:
+- FileVolatileSlice
+- FileVolatileBuf
+
+## License
+
+This project is licensed under [Apache License](http://www.apache.org/licenses/LICENSE-2.0), Version 2.0.

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -1,0 +1,339 @@
+// Copyright (C) 2021-2022 Alibaba Cloud. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+//! Provide data buffers to support [tokio] and [tokio-uring] based async io.
+//!
+//! The vm-memory v0.6.0 introduced support of dirty page tracking by using `Bitmap`, which adds a
+//! generic type parameters to several APIs. That's a breaking change and  makes the rust compiler
+//! fail to compile our code. So introduce [FileVolatileSlice] to mask out the `BitmapSlice`
+//! generic type parameter. Dirty page tracking is handled at higher level in `IoBuffers`.
+//!
+//! The [tokio-uring] crates uses [io-uring] for actual IO operations. And the [io-uring] APIs
+//! require passing ownership of buffers to the runtime. So [FileVolatileBuf] is introduced to
+//! support [tokio-uring] based async io.
+//!
+//! [io-uring]: https://github.com/tokio-rs/io-uring
+//! [tokio]: https://tokio.rs/
+//! [tokio-uring]: https://github.com/tokio-rs/tokio-uring
+
+use std::io::{Read, Write};
+use std::marker::PhantomData;
+use std::sync::atomic::Ordering;
+use std::{error, fmt};
+
+use vm_memory::{
+    bitmap::BitmapSlice, volatile_memory::Error as VError, AtomicAccess, Bytes, VolatileSlice,
+};
+
+/// Error codes related to buffer management.
+#[allow(missing_docs)]
+#[derive(Debug)]
+pub enum Error {
+    /// `addr` is out of bounds of the volatile memory slice.
+    OutOfBounds { addr: usize },
+    /// Taking a slice at `base` with `offset` would overflow `usize`.
+    Overflow { base: usize, offset: usize },
+    /// The error of VolatileSlice.
+    VolatileSlice(VError),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::OutOfBounds { addr } => write!(f, "address 0x{:x} is out of bounds", addr),
+            Error::Overflow { base, offset } => write!(
+                f,
+                "address 0x{:x} offset by 0x{:x} would overflow",
+                base, offset
+            ),
+            Error::VolatileSlice(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl error::Error for Error {}
+
+/// An adapter structure to work around limitations of the `vm-memory` crate.
+///
+/// It solves the compilation failure by masking out the  [`vm_memory::BitmapSlice`] generic type
+/// parameter of [`vm_memory::VolatileSlice`].
+///
+/// [`vm_memory::BitmapSlice`]: https://docs.rs/vm-memory/latest/vm_memory/bitmap/trait.BitmapSlice.html
+/// [`vm_memory::VolatileSlice`]: https://docs.rs/vm-memory/latest/vm_memory/volatile_memory/struct.VolatileSlice.html
+#[derive(Clone, Copy, Debug)]
+pub struct FileVolatileSlice<'a> {
+    addr: usize,
+    size: usize,
+    phantom: PhantomData<&'a u8>,
+}
+
+impl<'a> FileVolatileSlice<'a> {
+    /// Create a new instance of [`FileVolatileSlice`] from a raw pointer.
+    ///
+    /// # Safety
+    /// To use this safely, the caller must guarantee that the memory at `addr` is `size` bytes long
+    /// and is available for the duration of the lifetime of the new [FileVolatileSlice].
+    /// The caller must also guarantee that all other users of the given chunk of memory are using
+    /// volatile accesses.
+    ///
+    /// ### Example
+    /// ```rust
+    /// # use dbs_fuse::buf::FileVolatileSlice;
+    /// # use vm_memory::bytes::Bytes;
+    /// # use std::sync::atomic::Ordering;
+    /// let mut buffer = [0u8; 1024];
+    /// let s = unsafe { FileVolatileSlice::new(buffer.as_mut_ptr(), buffer.len()) };
+    ///
+    /// {
+    ///     let o: u32 = s.load(0x10, Ordering::Acquire).unwrap();
+    ///     assert_eq!(o, 0);
+    ///     s.store(1u8, 0x10, Ordering::Release).unwrap();
+    ///
+    ///     let s2 = s.as_volatile_slice();
+    ///     let s3 = FileVolatileSlice::new_from_volatile_slice(&s2);
+    ///     assert_eq!(s3.len(), 1024);
+    /// }
+    ///
+    /// assert_eq!(buffer[0x10], 1);
+    /// ```
+    pub unsafe fn new(addr: *mut u8, size: usize) -> Self {
+        Self {
+            addr: addr as usize,
+            size,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Create a new [`FileVolatileSlice`] from [`vm_memory::VolatileSlice`] and strip off the
+    /// [`vm_memory::BitmapSlice`].
+    ///
+    /// The caller needs to handle dirty page tracking for the data buffer.
+    ///
+    /// [`vm_memory::BitmapSlice`]: https://docs.rs/vm-memory/latest/vm_memory/bitmap/trait.BitmapSlice.html
+    /// [`vm_memory::VolatileSlice`]: https://docs.rs/vm-memory/latest/vm_memory/volatile_memory/struct.VolatileSlice.html
+    pub fn new_from_volatile_slice<S: BitmapSlice>(s: &VolatileSlice<'a, S>) -> Self {
+        unsafe { Self::new(s.as_ptr(), s.len()) }
+    }
+
+    /// Create a [`vm_memory::VolatileSlice`] from [FileVolatileSlice] without dirty page tracking.
+    ///
+    /// [`vm_memory::VolatileSlice`]: https://docs.rs/vm-memory/latest/vm_memory/volatile_memory/struct.VolatileSlice.html
+    pub fn as_volatile_slice(&self) -> VolatileSlice<'a, ()> {
+        unsafe { VolatileSlice::new(self.as_ptr(), self.len()) }
+    }
+
+    /// Return a pointer to the start of the slice.
+    pub fn as_ptr(&self) -> *mut u8 {
+        self.addr as *mut u8
+    }
+
+    /// Get the size of the slice.
+    pub fn len(&self) -> usize {
+        self.size
+    }
+
+    /// Check if the slice is empty.
+    pub fn is_empty(&self) -> bool {
+        self.size == 0
+    }
+
+    /// Return a subslice of this [FileVolatileSlice] starting at `offset`.
+    pub fn offset(&self, count: usize) -> Result<Self, Error> {
+        let new_addr = (self.addr as usize)
+            .checked_add(count)
+            .ok_or(Error::Overflow {
+                base: self.addr as usize,
+                offset: count,
+            })?;
+        let new_size = self
+            .size
+            .checked_sub(count)
+            .ok_or(Error::OutOfBounds { addr: new_addr })?;
+        unsafe { Ok(Self::new(new_addr as *mut u8, new_size)) }
+    }
+}
+
+impl<'a> Bytes<usize> for FileVolatileSlice<'a> {
+    type E = VError;
+
+    fn write(&self, buf: &[u8], addr: usize) -> Result<usize, Self::E> {
+        VolatileSlice::write(&self.as_volatile_slice(), buf, addr)
+    }
+
+    fn read(&self, buf: &mut [u8], addr: usize) -> Result<usize, Self::E> {
+        VolatileSlice::read(&self.as_volatile_slice(), buf, addr)
+    }
+
+    fn write_slice(&self, buf: &[u8], addr: usize) -> Result<(), Self::E> {
+        VolatileSlice::write_slice(&self.as_volatile_slice(), buf, addr)
+    }
+
+    fn read_slice(&self, buf: &mut [u8], addr: usize) -> Result<(), Self::E> {
+        VolatileSlice::write_slice(&self.as_volatile_slice(), buf, addr)
+    }
+
+    fn read_from<F>(&self, addr: usize, src: &mut F, count: usize) -> Result<usize, Self::E>
+    where
+        F: Read,
+    {
+        VolatileSlice::read_from(&self.as_volatile_slice(), addr, src, count)
+    }
+
+    fn read_exact_from<F>(&self, addr: usize, src: &mut F, count: usize) -> Result<(), Self::E>
+    where
+        F: Read,
+    {
+        VolatileSlice::read_exact_from(&self.as_volatile_slice(), addr, src, count)
+    }
+
+    fn write_to<F>(&self, addr: usize, dst: &mut F, count: usize) -> Result<usize, Self::E>
+    where
+        F: Write,
+    {
+        VolatileSlice::write_to(&self.as_volatile_slice(), addr, dst, count)
+    }
+
+    fn write_all_to<F>(&self, addr: usize, dst: &mut F, count: usize) -> Result<(), Self::E>
+    where
+        F: Write,
+    {
+        VolatileSlice::write_all_to(&self.as_volatile_slice(), addr, dst, count)
+    }
+
+    fn store<T: AtomicAccess>(&self, val: T, addr: usize, order: Ordering) -> Result<(), Self::E> {
+        VolatileSlice::store(&self.as_volatile_slice(), val, addr, order)
+    }
+
+    fn load<T: AtomicAccess>(&self, addr: usize, order: Ordering) -> Result<T, Self::E> {
+        VolatileSlice::load(&self.as_volatile_slice(), addr, order)
+    }
+}
+
+#[cfg(feature = "async-io")]
+pub use async_io::FileVolatileBuf;
+
+#[cfg(feature = "async-io")]
+mod async_io {
+    use super::*;
+
+    /// An adapter structure to support `io-uring` based asynchronous IO.
+    ///
+    /// The [tokio-uring] framework needs to take ownership of data buffers during asynchronous IO
+    /// operations. The [FileVolatileBuf] converts a referenced buffer to a buffer compatible with
+    /// the [tokio-uring] APIs.
+    ///
+    /// # Safety
+    /// The buffer is borrowed without a lifetime parameter, so the caller must ensure that
+    /// the [FileVolatileBuf] object doesn't out-live the borrowed buffer. And during the lifetime
+    /// of the [FileVolatileBuf] object, the referenced buffer must be stable.
+    ///
+    /// [tokio-uring]: https://github.com/tokio-rs/tokio-uring
+    #[allow(dead_code)]
+    #[derive(Clone, Copy, Debug)]
+    pub struct FileVolatileBuf {
+        addr: usize,
+        size: usize,
+        cap: usize,
+    }
+
+    impl FileVolatileBuf {
+        /// Create a [FileVolatileBuf] object from a buffer.
+        pub unsafe fn new(buf: &mut [u8]) -> Self {
+            Self {
+                addr: buf.as_mut_ptr() as usize,
+                size: 0,
+                cap: buf.len(),
+            }
+        }
+
+        /// Create a [FileVolatileBuf] object from a raw pointer.
+        pub unsafe fn from_raw(addr: *mut u8, size: usize, cap: usize) -> Self {
+            Self {
+                addr: addr as usize,
+                size,
+                cap,
+            }
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    unsafe impl tokio_uring::buf::IoBuf for FileVolatileBuf {
+        fn stable_ptr(&self) -> *const u8 {
+            self.addr as *const u8
+        }
+
+        fn bytes_init(&self) -> usize {
+            self.size
+        }
+
+        fn bytes_total(&self) -> usize {
+            self.cap
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    unsafe impl tokio_uring::buf::IoBufMut for FileVolatileBuf {
+        fn stable_mut_ptr(&mut self) -> *mut u8 {
+            self.addr as *mut u8
+        }
+
+        unsafe fn set_init(&mut self, pos: usize) {
+            self.size = pos;
+        }
+    }
+
+    impl<'a> FileVolatileSlice<'a> {
+        /// Borrow a [FileVolatileSlice] to temporarily elide the lifetime parameter.
+        ///
+        /// # Safety
+        /// The [FileVolatileSlice] is borrowed without a lifetime parameter, so the caller must
+        /// ensure that [FileVolatileBuf] doesn't out-live the borrowed [FileVolatileSlice] object.
+        pub unsafe fn borrow_mut(&self) -> FileVolatileBuf {
+            FileVolatileBuf {
+                addr: self.addr,
+                size: 0,
+                cap: self.size,
+            }
+        }
+    }
+
+    #[cfg(all(test, target_os = "linux"))]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn test_new_file_volatile_buf() {
+            let mut buf = [0u8; 1024];
+            let mut buf2 = unsafe { FileVolatileBuf::new(&mut buf) };
+            assert_eq!(buf2.bytes_total(), 1024);
+            assert_eq!(buf2.bytes_init(), 0);
+            assert_eq!(buf2.stable_ptr(), buf.as_ptr());
+            unsafe { *buf2.stable_mut_ptr() = b'a' };
+            assert_eq!(buf[0], b'a');
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_file_volatile_slice() {
+        let mut buffer = [0u8; 1024];
+        let s = unsafe { FileVolatileSlice::new(buffer.as_mut_ptr(), buffer.len()) };
+
+        let o: u32 = s.load(0x10, Ordering::Acquire).unwrap();
+        assert_eq!(o, 0);
+        s.store(1u8, 0x10, Ordering::Release).unwrap();
+
+        let s2 = s.as_volatile_slice();
+        let s3 = FileVolatileSlice::new_from_volatile_slice(&s2);
+        assert_eq!(s3.len(), 1024);
+
+        assert!(s3.offset(2048).is_err());
+
+        assert_eq!(buffer[0x10], 1);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,14 @@
+// Copyright (C) 2022 Alibaba Cloud. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+//! A utility crate to support [fuse-backend-rs](https://github.com/cloud-hypervisor/fuse-backend-rs)
+//!
+//! ### Wrappers for Rust async io
+//! It's challenging to support Rust async io, and it's even more challenging to support Rust async io with Linux io-uring.
+//!
+//! The `dbs-fuse` crate adds a wrapper layer over [tokio](https://tokio.rs/) and [tokio-uring](https://github.com/tokio-rs/tokio-uring) to simplify the way to support Rust async io by providing:
+//! - [FileVolatileSlice](crate::buf::FileVolatileSlice): An adapter structure to work around limitations of the `vm-memory` crate.
+//! - [FileVolatileBuf](crate::buf::FileVolatileBuf): An adapter structure to support `io-uring` based asynchronous IO.
+
+pub mod buf;


### PR DESCRIPTION
Move FileVolatileSlice/FileVolatileBuf from fuse-backend so it could
be reused later.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>