### PR TITLE
buf: expose FileVolatileBuf for non-async-io mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbs-fuse"
-version = "0.1.0"
+version = "0.1.1"
 license = "Apache-2.0"
 authors = ["Alibaba Dragonball Team"]
 description = "Utilities for tokio/tokio-uring based async IO"


### PR DESCRIPTION
Expose FileVolatileBuf for non-async-io mode.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>