### PR TITLE
file: use the extended tokio-uring crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ vmm-sys-util = "0.9.0"
 tokio = { version = "1", features = ["macros"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-tokio-uring = "0.3"
+tokio-uring = { git = "https://github.com/jiangliu/tokio-uring.git", branch = "dbs-fuse" }
 
 [features]
 async-io = ["async-trait", "futures", "tokio/fs", "tokio/sync"]


### PR DESCRIPTION
Use the extended tokio-uring crate to improve the Runtime and File
implementation.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>